### PR TITLE
Fix cache putting mechanism

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -6,9 +6,11 @@ const cityNames = [
     {%- endfor -%}
 ];
 
+const version = 'v{{ site.version }}';
+
 self.addEventListener("install", (event) => {
     event.waitUntil(
-        caches.open('v{{ site.version }}').then((cache) => {
+        caches.open(version).then((cache) => {
             return cache.addAll([
                 "./",
                 "index.html",
@@ -36,9 +38,9 @@ self.addEventListener("fetch", (event) => {
             return fetch(event.request.clone())
                 .then(response => {
                     if (response.status < 400) {
-                        caches.put(event.request, response.clone())
+                        caches.open(version).then(cache => cache.put(event.request, response));
+                        return response.clone();
                     } else {
-                        console.log('404ing');
                         const req404 = new Request("/404.html");
                         return caches.match(req404);
                     }
@@ -52,7 +54,7 @@ self.addEventListener('activate', (event) => {
       caches.keys().then((cacheNames) => {
         return Promise.all(
             cacheNames.filter((cacheName) => {
-                return cacheName !== 'v{{ site.version }}';
+                return cacheName !== version;
             }).map((cacheName) => {
                 return caches.delete(cacheName);
             })


### PR DESCRIPTION
Fixes `caches.put is not a function` error when accessing new resources.

To test this try using the Sa11y bookmark on the production page and note the error, then try on the deploy preview and notice that it works: https://ryersondmp.github.io/sa11y/#bookmarklet-experimental

This is a valid test because it causes the service worker to check its cache before making a request, we want it to successfully make the request out to the real internet and then put the response into the cache AND return the response. Right now we were just doing a (bad) put and not returning the response. This fixes both issues.