### PR TITLE
Skip waiting

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -9,6 +9,8 @@ const cityNames = [
 const version = 'v{{ site.version }}';
 
 self.addEventListener("install", (event) => {
+    self.skipWaiting();
+
     event.waitUntil(
         caches.open(version).then((cache) => {
             return cache.addAll([


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/skipWaiting

This makes sense for our app because there's never a reason for the existing service worker to stick around if there's a new one available.