### PR TITLE
Add new resource form page

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -13,6 +13,10 @@
     {% endif %}
 
     <p>
+        To request a new resource be added, please visit <a href="/new-resource">this page and fill the form</a>. Thanks in advance for your contribution!
+    </p>
+
+    <p>
         To report any corrections to this site, either fill in the form below, email us at <a href="mailto:techblocsea@protonmail.com">techblocsea@protonmail.com</a>, or message us on <a href="https://twitter.com/TechBlocSEA">Twitter</a>.
     </p>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <meta http-equiv="x-ua-compatible" content="ie=edge">
-<title>Not 911 - {{ page.title }}</title>
+<title>{{ page.title }} | Not 911</title>
 <link id="favicon" rel="icon" href="/favicon.ico" type="image/x-icon">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="List of alternatives to calling 911 in Seattle">
@@ -8,6 +8,9 @@
 <meta name="theme-color" content="#ff0080">
 
 <link rel="stylesheet" href="/style.css">
+{% if page.stylesheet %}
+    <link rel="stylesheet" href="{{ page.stylesheet }}">
+{% endif %}
 <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="128x128">
 <link rel="icon" sizes="192x192" href="/apple-touch-icon.png">
 <link rel="manifest" href="/not911.webmanifest">

--- a/_includes/new-resource.scss
+++ b/_includes/new-resource.scss
@@ -1,0 +1,32 @@
+aside {
+    margin-top: 0;
+    font-size: 0.75rem;
+    font-weight: bold
+}
+
+form p {
+    margin-bottom: 0;
+}
+
+.flex-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    flex-wrap: nowrap;
+    margin: 0.25rem;
+}
+
+form .flex-row input {
+    width: initial;
+    margin: 0 0.5rem 0 0;
+}
+
+form .flex-row label {
+    padding-top: 0.25rem;
+}
+
+.required::before {
+    content: '* ';
+    color: red;
+}

--- a/_includes/resource_types.html
+++ b/_includes/resource_types.html
@@ -14,4 +14,8 @@
             <a href="#{{ resource_type.slug }}">{{ resource_type.title }}</a>
         {% endfor %}
     </div>
+
+    <p>
+        To request a new resource be added, please visit <a href="/new-resource">this page and fill the form</a>. Thanks in advance for your contribution!
+    </p>
 </section>

--- a/new-resource.css
+++ b/new-resource.css
@@ -1,0 +1,7 @@
+---
+---
+
+{% capture include_to_scssify %}
+    {% include new-resource.scss %}
+{% endcapture %}
+{{ include_to_scssify | scssify | strip_newlines }}

--- a/new-resource.md
+++ b/new-resource.md
@@ -1,0 +1,90 @@
+---
+layout: default
+title: New Resource
+stylesheet: /new-resource.css
+---
+
+<a href="/">Back to the list</a>
+
+<h2>New Resource Request</h2>
+
+<p>
+    Thank you for taking an interest in helping us expand this list of resources. To request a new resource be added, please fill the form below. Please note that the information sent in the form is not private and can be read by our web host, Netlify. There's nothing we can do about this at this time without significantly increasing the cost to run this website. If you'd prefer to contact us directly, please email us at <a href="mailto:techblocsea@protonmail.com">techblocsea@protonmail.com</a>.
+</p>
+
+<form name="new-resource" data-netifly="true" method="POST">
+    <p>An asterisk (*) denotes a required field</p>
+    <p>
+        <label for="submitter-email">Your Email (optional):</label>
+        <aside>Include this if you feel comfortable with us following up with you about this resource. It is extremely helpful for us to be able to do so and will increase the likelihood that the resource will be included.</aside>
+        <input id="submitter-email" type="email" name="submitter-email" />
+    </p>
+    <p>
+        <label class="required">Resource name: <input type="text" required name="name" /></label>
+    </p>
+    <p>
+        <label>Resource URL (if available): <input type="url" name="url" /></label>
+    </p>
+    <p>
+        <label class="required" for="phone">Resource phone:</label>
+        <aside>If there are additional phone numbers, please list them in the dscription</aside>
+        <input id="phone" type="tel" required name="phone" />
+    </p>
+    <p>
+        <label for="resource-email">Resource email:</label>
+        <aside>If available, any contact you have at the organization behind the resource or a general purpose email for the organization</aside>
+        <input id="resource-email" type="email" name="resource-email" />
+    </p>
+    <p>
+        <label class="required" for="category">Resource category:</label>
+        <aside>Please choose at least one. To select multiple on PC, hold control (or command if on a mac) and click on each option you wish to select.</aside>
+        <select id="category" name="category" multiple required>
+            {% for resource_type in site.resource_types %}
+                <option value="{{ resource_type.slug }}">{{ resource_type.title }}</option>
+            {% endfor %}
+        </select>
+    </p>
+    <p>
+        <label class="required" for="description">Resource description:</label>
+        <aside>If there are additional phone numbers, please list them here</aside>
+        <textarea id="description" name="description" required></textarea>
+    </p>
+    <p>
+        <div class="required">Have you vetted this resource for whether they work with the cops?</div>
+        <div class="flex-row">
+            <input id="vetted-yes" required type="radio" name="vetted" value="yes">
+            <label for="vetted-yes">Yes, I have vetted this resource.</label>
+        </div>
+        <div class="flex-row">
+            <input id="vetted-no" required type="radio" name="vetted" value="no">
+            <label for="vetted-no">No, I have not vetted this resource.</label>
+        </div>
+    </p>
+    <p>
+        <div class="required">If you have vetted the resource, confirm whether the work with the police to the best of your knowledge.</div>
+        <div class="flex-row">
+            <input id="cops-unknown" required type="radio" name="cops" value="unknown">
+            <label for="cops-unknown">I do not know if this resource works with the cops, whether on a regular basis or under specific circumstances.</label>
+        </div>
+        <div class="flex-row">
+            <input id="cops-yes" required type="radio" name="cops" value="yes">
+            <label for="cops-yes">Yes, this resource works with the cops under certain circumstances.</label>
+        </div>
+        <div class="flex-row">
+            <input id="cops-no" required type="radio" name="cops" value="no">
+            <label for="cops-no">No, this resource does not work with the cops.</label>
+        </div>
+    </p>
+    <p>
+        <label class="required" for="why-include">
+            If to your knowledge the resource works with the cops, please describe why you feel it would still be a worthwhile inclusion into the list of resources.</label>
+        <aside>If you have indicated above that the resource does not work with the cops, please write "not applicable".</aside>
+        <textarea required id="why-include" name="why-include"></textarea>
+    </p>
+    <p>
+        <label>Additional notes: <textarea name="notes"></textarea></label>
+    </p>
+    <p>
+        <button type="submit">Submit correction</button>
+    </p>
+</form>


### PR DESCRIPTION
Adds a new resource form page.

To test, go to the deploy preview, click the link to visit the new resource page and submit the form with test data. Verify either in the email inbox or in Netlify that the form has been picked up.